### PR TITLE
Avoid characters in file names that are illegal in Windows

### DIFF
--- a/Examples/GenerateDoc.mos
+++ b/Examples/GenerateDoc.mos
@@ -89,8 +89,12 @@ function filename \"Replace characters that mess with filesystems and shell expa
   input String str;
   output String ostr :=
         OpenModelica.Scripting.stringReplace(
-          OpenModelica.Scripting.stringReplace(str,\"/\",\"Division\"),
-          \"*\",\"Multiplication\")
+        OpenModelica.Scripting.stringReplace(
+        OpenModelica.Scripting.stringReplace(
+        OpenModelica.Scripting.stringReplace(str,\"/\",\"Division\"),
+        \"*\",\"Multiplication\"),
+        \"<\",\"x3C\"),
+        \">\",\"x3E\")
 ;
 end filename;
 
@@ -100,6 +104,8 @@ function uriEncode
 algorithm
   uri := OpenModelica.Scripting.stringReplace(str,\"'\",\"%27\");
   uri := OpenModelica.Scripting.stringReplace(uri,\" \",\"%20\");
+  uri := OpenModelica.Scripting.stringReplace(uri,\"<\",\"x3C\");
+  uri := OpenModelica.Scripting.stringReplace(uri,\">\",\"x3E\");
 end uriEncode;
 
 function notLast


### PR DESCRIPTION
In https://trac.modelica.org/Modelica/ticket/2024 it was noticed that
the help files generated by this OMC script contained the under
Windows illegal characters '<' and '>'. This patch fixes that issue.

The characters are replaced by something that resambles URI encoding
but not quite since using actual "%3C" causes other issues when overly
clever browser revert "%3c" into "<" and hence the filename can not
be found by the browser. Therefore this patch uses "x3C" and "x3E".
